### PR TITLE
JSON API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     flask-googlemaps
     Flask-CacheControl
     Flask-Caching
+    flask_cors
     influxdb3-python
     pandas
     simplejson

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     Flask-Caching
     influxdb3-python
     pandas
+    simplejson
 
 [options.packages.find]
 where=src

--- a/src/wscearth/__init__.py
+++ b/src/wscearth/__init__.py
@@ -2,6 +2,7 @@
 
 from flask import Flask
 from flask_caching import Cache
+from flask_cors import CORS
 
 config = {
     "DEBUG": True,          # some Flask specific configs
@@ -11,6 +12,7 @@ config = {
 app = Flask(__name__)
 app.config.from_mapping(config)
 cache = Cache(app)
+cors = CORS(app)
 
 import wscearth.views # pylint: disable=wrong-import-position
 

--- a/src/wscearth/static/positions.js
+++ b/src/wscearth/static/positions.js
@@ -8,7 +8,7 @@ window.wsc = (function() {
   // API utilities.
   const api = (function() {
     const telemetry = new URL(document.currentScript.src);
-    const sprout = new URL('http://sola.gwilyn.bunnysites.com');
+    const sprout = new URL('https://worldsolarchallenge.org');
 
     // Generic fetch.
     async function get(base, uri, params = {}) {

--- a/src/wscearth/static/positions.js
+++ b/src/wscearth/static/positions.js
@@ -51,6 +51,28 @@ window.wsc = (function() {
     }
   })();
 
+  const loop = (function() {
+    let timer = 0;
+
+    function start(timeout = 5000) {
+      clearInterval(timer);
+
+      timer = setInterval(async () => {
+        data = await api.getPositions();
+        updateMarkers();
+      }, timeout);
+    }
+
+    function stop() {
+      clearInterval(timer);
+    }
+
+    return {
+      start,
+      stop,
+    }
+  })();
+
   // Create/update markers on the map, deduplicated by shortname.
   function updateMarkers() {
     for (let item of data.items) {
@@ -170,15 +192,14 @@ window.wsc = (function() {
     updateMarkers();
 
     // Loop it.
-    setInterval(async () => {
-      data = await api.getPositions();
-      updateMarkers(data.items);
-    }, 5000);
+    loop.start();
   }
 
   window.__wscinitMap = initMap;
 
   return {
+    api,
+    loop,
     markers,
     updateMarkers,
     drawPath,

--- a/src/wscearth/static/positions.js
+++ b/src/wscearth/static/positions.js
@@ -14,6 +14,18 @@ window.wsc = (function() {
     return json;
   }
 
+  async function getPaths(shortname) {
+    const res = await fetch('api/path/' + shortname);
+
+    if (!res.ok) {
+      const message = `${res.status}: ` + await res.text();
+      throw new Error(message);
+    }
+
+    const json = await res.json();
+    return json;
+  }
+
   function updateMarkers(items) {
 
     for (let item of items) {
@@ -54,6 +66,20 @@ window.wsc = (function() {
     }
   }
 
+  async function drawPath(shortname) {
+    const path = await getPaths(shortname);
+
+    const poly = new google.maps.Polyline({
+      path: path.map(item => ({ lat: item.latitude, lng: item.longitude })),
+      geodesic: true,
+      strokeColor: '#FF0000',
+      strokeOpacity: 1.0,
+      strokeWeight: 2,
+    });
+
+    poly.setMap(map);
+  }
+
   async function initMap() {
     if (map) {
       throw new Error('already initialized');
@@ -92,10 +118,10 @@ window.wsc = (function() {
   window.__wscinitMap = initMap;
 
   return {
-    map,
     markers,
     getPositions,
     updateMarkers,
+    drawPath,
     initMap,
   }
 })();

--- a/src/wscearth/static/positions.js
+++ b/src/wscearth/static/positions.js
@@ -1,0 +1,101 @@
+window.wsc = (function() {
+  let map;
+  const markers = {};
+
+  async function getPositions() {
+    const res = await fetch('api/positions');
+
+    if (!res.ok) {
+      const message = `${res.status}: ` + await res.text();
+      throw new Error(message);
+    }
+
+    const json = await res.json();
+    return json;
+  }
+
+  function updateMarkers(items) {
+
+    for (let item of items) {
+
+      if (!item.shortname) {
+        console.warn('missing shortname:', item);
+        continue;
+      }
+
+      if (
+        typeof item.latitude !== 'number'
+        || typeof item.latitude !== 'number'
+      ) {
+        console.warn('invalid position:', item);
+        continue;
+      }
+
+      let marker = markers[item.shortname];
+
+      // Update existing markers.
+      if (marker) {
+        marker.setPosition({
+          lat: item.latitude,
+          lng: item.longitude,
+        });
+        continue;
+      }
+
+      // It's a new marker.
+      markers[item.shortname] = new google.maps.Marker({
+        map: map,
+        title: item.shortname,
+        position: {
+          lat: item.latitude,
+          lng: item.longitude,
+        }
+      });
+    }
+  }
+
+  async function initMap() {
+    if (map) {
+      throw new Error('already initialized');
+    }
+
+    map = new google.maps.Map(document.getElementById("map"), {
+      center: { lat: -25.0, lng: 133.0 },
+      zoom: 4,
+    });
+
+    // Create an info window to share between markers.
+    const infoWindow = new google.maps.InfoWindow();
+
+    const data = await getPositions();
+
+    // Initial map position based on the mean of all positions.
+    map.setCenter(data.center);
+    updateMarkers(data.items);
+
+    // Add a click listener for each marker, and set up the info window.
+    for (let marker of Object.values(markers)) {
+      marker.addListener("click", () => {
+        infoWindow.close();
+        infoWindow.setContent(marker.getTitle());
+        infoWindow.open(marker.getMap(), marker);
+      })
+    }
+
+    // Loop it.
+    setInterval(async () => {
+      const data = await getPositions();
+      updateMarkers(data.items);
+    }, 5000);
+  }
+
+  window.__wscinitMap = initMap;
+
+  return {
+    map,
+    markers,
+    getPositions,
+    updateMarkers,
+    initMap,
+  }
+})();

--- a/src/wscearth/static/style.css
+++ b/src/wscearth/static/style.css
@@ -1,0 +1,48 @@
+#map {
+    height: 100%;
+}
+
+html, body {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+}
+
+/* Map popup boxes */
+.map-popup {
+	padding: 15px;
+}
+
+.map-popup img {
+	margin: 0 10px 0 0;
+}
+
+.map-popup a {
+	color: #222;
+}
+
+.map-popup .name {
+	margin-bottom: 20px;
+	text-align: center;
+	background: #eee;
+	padding: 10px;
+}
+
+.map-popup b {
+	display: inline-block;
+	width: 200px;
+}
+
+.map-popup span {
+	display: inline-block;
+	width: 200px;
+}
+
+.map-popup span > i {
+	font-style: normal;
+	border-bottom: 1px #666 dotted;
+}
+
+.map-popup .info {
+	font-size: 11px;
+}

--- a/src/wscearth/templates/positions_map.html
+++ b/src/wscearth/templates/positions_map.html
@@ -12,105 +12,6 @@
       }
     </style>
 
-    <script>
-    window.wsc = (function() {
-      let map;
-      const markers = {};
-
-      async function getPositions() {
-        const res = await fetch('api/positions');
-
-        if (!res.ok) {
-          const message = `${res.status}: ` + await res.text();
-          throw new Error(message);
-        }
-
-        const json = await res.json();
-        return json;
-      }
-
-      function updateMarkers(items) {
-
-        for (let item of items) {
-
-          if (!item.shortname) {
-            console.warn('missing shortname:', item);
-            continue;
-          }
-
-          if (
-            typeof item.latitude !== 'number'
-            || typeof item.longitude !== 'number'
-          ) {
-            console.warn('invalid position:', item);
-            continue
-          }
-
-          let marker = markers[item.shortname];
-
-          // Update existing markers.
-          if (marker) {
-            marker.setPosition({
-              lat: item.latitude,
-              lng: item.longitude,
-            });
-            continue;
-          }
-
-          // It's a new marker.
-          markers[item.shortname] = new google.maps.Marker({
-            map: map,
-            title: item.shortname,
-            position: {
-              lat: item.latitude,
-              lng: item.longitude,
-            }
-          });
-        }
-      }
-
-      async function initMap() {
-        map = new google.maps.Map(document.getElementById("map"), {
-          center: { lat: -25.0, lng: 133.0 },
-          zoom: 4,
-        });
-
-        // Create an info window to share between markers.
-        const infoWindow = new google.maps.InfoWindow();
-
-        const data = await getPositions();
-
-        // Initial map position based on the mean of all positions.
-        map.setCenter(data.center);
-        updateMarkers(data.items);
-
-        // Add a click listener for each marker, and set up the info window.
-        for (let marker of Object.values(markers)) {
-          marker.addListener("click", () => {
-            infoWindow.close();
-            infoWindow.setContent(marker.getTitle());
-            infoWindow.open(marker.getMap(), marker);
-          })
-        }
-
-        // Loop it.
-        setInterval(async () => {
-          const data = await getPositions();
-          updateMarkers(data.items);
-        }, 5000);
-      }
-
-      window.initMap = initMap;
-
-      return {
-        map,
-        markers,
-        getPositions,
-        updateMarkers,
-      }
-    })();
-    </script>
-
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-MXGQHB1S3T"></script>
     <script>
@@ -125,9 +26,11 @@
   <body>
     <div id="map"></div>
 
+    <script src="/static/positions.js"></script>
+
     <!-- Async script executes immediately and must be after any DOM elements used in callback. -->
     <script
-      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyD4cxmf6zr3SMovEYgZZe9eoEQCglqz3L8&callback=initMap&v=weekly"
+      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyD4cxmf6zr3SMovEYgZZe9eoEQCglqz3L8&callback=__wscinitMap&v=weekly"
       async
     ></script>
   </body>

--- a/src/wscearth/templates/positions_map.html
+++ b/src/wscearth/templates/positions_map.html
@@ -13,41 +13,102 @@
     </style>
 
     <script>
+    window.wsc = (function() {
       let map;
+      const markers = {};
 
-      function initMap() {
+      async function getPositions() {
+        const res = await fetch('api/positions');
+
+        if (!res.ok) {
+          const message = `${res.status}: ` + await res.text();
+          throw new Error(message);
+        }
+
+        const json = await res.json();
+        return json;
+      }
+
+      function updateMarkers(items) {
+
+        for (let item of items) {
+
+          if (!item.shortname) {
+            console.warn('missing shortname:', item);
+            continue;
+          }
+
+          if (
+            typeof item.latitude !== 'number'
+            || typeof item.longitude !== 'number'
+          ) {
+            console.warn('invalid position:', item);
+            continue
+          }
+
+          let marker = markers[item.shortname];
+
+          // Update existing markers.
+          if (marker) {
+            marker.setPosition({
+              lat: item.latitude,
+              lng: item.longitude,
+            });
+            continue;
+          }
+
+          // It's a new marker.
+          markers[item.shortname] = new google.maps.Marker({
+            map: map,
+            title: item.shortname,
+            position: {
+              lat: item.latitude,
+              lng: item.longitude,
+            }
+          });
+        }
+      }
+
+      async function initMap() {
         map = new google.maps.Map(document.getElementById("map"), {
-          {% if df.empty %}
           center: { lat: -25.0, lng: 133.0 },
           zoom: 4,
-          {% else %}
-          center: { lat: {{centre_lat}}, lng: {{centre_long}} },
-          zoom: 3,
-          {% endif %}
         });
 
         // Create an info window to share between markers.
         const infoWindow = new google.maps.InfoWindow();
 
-        const markers = [];
-        {% for index,row in df.iterrows() %}
-        markers.push(new google.maps.Marker({
-          position: { lat: {{ row["latitude"] }}, lng: {{ row["longitude"] }} },
-          map: map,
-          title: '{{ row["shortname"] }}'
-        }));
-        {% endfor %}
+        const data = await getPositions();
 
-        markers.map((marker) => {
-          // Add a click listener for each marker, and set up the info window.
+        // Initial map position based on the mean of all positions.
+        map.setCenter(data.center);
+        updateMarkers(data.items);
+
+        // Add a click listener for each marker, and set up the info window.
+        for (let marker of Object.values(markers)) {
           marker.addListener("click", () => {
             infoWindow.close();
             infoWindow.setContent(marker.getTitle());
             infoWindow.open(marker.getMap(), marker);
-          } )
-        })
+          })
+        }
 
+        // Loop it.
+        setInterval(async () => {
+          const data = await getPositions();
+          updateMarkers(data.items);
+        }, 5000);
       }
+
+      window.initMap = initMap;
+
+      return {
+        map,
+        markers,
+        getPositions,
+        updateMarkers,
+      }
+    })();
     </script>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/src/wscearth/templates/positions_map.html
+++ b/src/wscearth/templates/positions_map.html
@@ -1,16 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <style>
-      #map {
-        height: 100%;
-      }
-      html, body {
-        height: 100%;
-        margin: 0;
-        padding: 0;
-      }
-    </style>
+    <link rel="stylesheet" href="/static/style.css">
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-MXGQHB1S3T"></script>

--- a/src/wscearth/views.py
+++ b/src/wscearth/views.py
@@ -91,8 +91,8 @@ GROUP BY shortname"""
         }
     else:
         center = {
-            "lat": df["last_latitude"].mean(),
-            "lng": df["last_longitude"].mean(),
+            "lat": df["latitude"].mean(),
+            "lng": df["longitude"].mean(),
         }
 
     # We're in 2023 and this the best Python can do?

--- a/src/wscearth/views.py
+++ b/src/wscearth/views.py
@@ -53,10 +53,24 @@ def index():
     return flask.render_template("positions_map.html")
 
 
+@app.route("/api/path/<shortname>")
+def api_path(shortname):
+    """Render JSON path positions for car"""
+
+    query = f'SELECT * FROM "telemetry" WHERE shortname = \'{shortname}\' and time >= -30d'
+    table = client.query(query=query, database=INFLUX_BUCKET, language="influxql")
+
+    df = table.select(['time', 'latitude', 'longitude', 'altitude', 'solarEnergy']) \
+        .to_pandas() \
+        .sort_values(by="time")
+
+    return df.to_json(orient="records")
+
+
 @app.route("/api/positions")
 @cache.cached(timeout=30)
 @flask_cachecontrol.cache_for(seconds=30)
-def positions():
+def api_positions():
     """Render a positions JSON"""
 #    query = "select * from telemetry GROUP BY car"
     query = """\

--- a/src/wscearth/views.py
+++ b/src/wscearth/views.py
@@ -6,6 +6,7 @@ import flask
 import flask_cachecontrol
 import flask_googlemaps
 from influxdb_client_3 import InfluxDBClient3
+import simplejson as json
 
 # Circular import recommended here: https://flask.palletsprojects.com/en/3.0.x/patterns/packages/
 from wscearth import app,cache # pylint: disable=cyclic-import
@@ -47,8 +48,16 @@ flask_googlemaps.GoogleMaps(app)
 @app.route("/")
 @cache.cached(timeout=30)
 @flask_cachecontrol.cache_for(seconds=30)
+def index():
+    """Render a Google map"""
+    return flask.render_template("positions_map.html")
+
+
+@app.route("/api/positions")
+@cache.cached(timeout=30)
+@flask_cachecontrol.cache_for(seconds=30)
 def positions():
-    """Render a positions map"""
+    """Render a positions JSON"""
 #    query = "select * from telemetry GROUP BY car"
     query = """\
 SELECT LAST(latitude),latitude,longitude,*
@@ -75,12 +84,22 @@ GROUP BY shortname"""
     #    print(row)
 
     if len(df) == 0:
-        return flask.render_template("positions_map.html",
-                                    centre_lat=-25.0,
-                                    centre_long=130.0,
-                                    df=[])
+        df = []
+        center = {
+            "lat": -25.0,
+            "lng": 130.0,
+        }
+    else:
+        center = {
+            "lat": df["last_latitude"].mean(),
+            "lng": df["last_longitude"].mean(),
+        }
 
-    return flask.render_template("positions_map.html",
-                                    centre_lat=df["latitude"].mean(),
-                                    centre_long=df["longitude"].mean(),
-                                    df=df)
+    # We're in 2023 and this the best Python can do?
+    items = json.loads(df.to_json(orient="records"))
+
+    return json.dumps({
+        "center": center,
+        "items": items,
+    }, ignore_nan=True)
+


### PR DESCRIPTION
This moves all the positional data into a JSON API.

A few benefits:
- we can poll the data regularly
- we can import this into the main WSC site
- proper serialisation keeps the data from corrupting

There's a script file that creates a 'wsc' global var with all the bits we need to integrate into the main site. For the most part though, all the visualisation magic is done within this script file. The template HTML won't be used by the live site, but provides a good demo/hack space.

The popup HTML is straight from the old map in 2019.

I've also included an API to fetch static data from the CMS. This isn't deployed yet.

## Testing

This is tested locally within our own environment. We can get a test page on live or bunnysites going soon.
